### PR TITLE
Update settings to accomodate CF mongo creds

### DIFF
--- a/macreduce/settings.py
+++ b/macreduce/settings.py
@@ -51,10 +51,10 @@ if VCAP_CONFIG:
         # Looking for an instance of a Mongo Bluemix Service
         if key.startswith('mongo'):
             mongo_creds = decoded_config[key][0]['credentials']
-            seq = (r'^mongodb\:\/\/(?P<username>[_\w]+):(?P<password>[-\w]+)@'
-                   '(?P<host>[\.\w]+):(?P<port>\d+)/(?P<database>[_\w]+).*?$')
+            seq = (r'^mongodb\:\/\/(?P<username>[\W\w]+):(?P<password>[\W\w]+)@'
+                   '(?P<host>[\.\w]+):(?P<port>\d+)/(?P<database>[\W\w]+).*?$')
             regex = re.compile(seq)
-            match = regex.search(mongo_creds['uri'])
+            match = regex.search(mongo_creds['url'])
             # Deconstruct MongoURL connection information
             parseURI = match.groupdict()
             MONGO_HOST = parseURI['host']


### PR DESCRIPTION
With the removal of MongoLabs (mlab) from the Bluemix catalog, the only free service instance available is the CF mongo service.  The generated credentials provide a key named "url" vs. "uri" that requires update.  I've also broadened the regex to be more permissive by matching non-alphanumerics using \W and alphanumerics using \w  vs. being more explicit about allowed characters within username, password, host and database fields.
